### PR TITLE
Added filter for strings with commas inside of it

### DIFF
--- a/js/read-csv.js
+++ b/js/read-csv.js
@@ -26,7 +26,7 @@ function processData(csv) {
     var allTextLines = csv.split(/\r\n|\n/);
     var lines = [];
     while (allTextLines.length) {
-        lines.push(allTextLines.shift().split(','));
+        lines.push(clearLine(allTextLines.shift());
     }
 	console.log(lines);
 	drawOutput(lines);
@@ -34,7 +34,7 @@ function processData(csv) {
 
 function errorHandler(evt) {
 	if(evt.target.error.name == "NotReadableError") {
-		alert("Canno't read file !");
+		alert("Cannot read file!");
 	}
 }
 
@@ -50,4 +50,36 @@ function drawOutput(lines){
 		}
 	}
 	document.getElementById("output").appendChild(table);
+}
+
+/**
+ * Prevents the splitting of items with double quotes.
+ * @param  {string} line line string
+ * @return {string}      correctly splitted string
+ */
+function clearLine(line) {
+        var splitline = line.split(',')
+        var new_string = []
+        var separated_string = []
+        var is_separated_string = false
+        for (v in splitline) {
+                var item = splitline[v]
+                if (item.includes('"')) {
+                        separated_string.push(item.replace('"', ''))
+                        if (!is_separated_string) {
+                                is_separated_string = true
+                        } else {
+                                is_separated_string = false
+                                new_string.push(separated_string.join(', '))
+                                separated_string = []
+                        }
+                } else {
+                        if (is_separated_string) {
+                                separated_string.push(item)
+                        } else if (!is_separated_string) {
+                                new_string.push(item)
+                        }
+                }
+        }
+        return new_string
 }


### PR DESCRIPTION
Sometimes we want to parse information that contains commas inside the cell, so we can't split that information into two or more cells. Instead, we filter those splitted erroneously and join them again.

For example: the string "My Company, Inc." is the kind of data that can be found in a cell, but should not be split. This new function will detect the two parts `"My Company` and ` Inc"` and join them again using the comma.